### PR TITLE
Move errors module from the old client

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,10 +16,23 @@ The format is based on `Keep a Changelog`_, and this project adheres to
 Unreleased_
 -----------
 
+Added
+~~~~~
+
+* `ValueError` raised by `ReqlTimeoutError` and `ReqlAuthError` if only host or port set
+
 Changed
 ~~~~~~~
 
+* QueryPrinter's `print_query` became a property and renamed to `query`
+* QueryPrinter's `print_carrots` became a property and renamed to `carrots`
+* Renamed `ReqlAvailabilityError` to `ReqlOperationError`
 * Extract REPL helper class to a separate file
+
+Removed
+~~~~~~~
+
+* Removed `Rql*` aliases for `Reql*` exceptions
 
 .. EXAMPLE CHANGELOG ENTRY
 

--- a/docs/rethinkdb.rst
+++ b/docs/rethinkdb.rst
@@ -4,6 +4,14 @@ rethinkdb package
 Submodules
 ----------
 
+rethinkdb.errors module
+-----------------------
+
+.. automodule:: rethinkdb.errors
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 rethinkdb.ql2\_pb2 module
 -------------------------
 

--- a/rethinkdb/errors.py
+++ b/rethinkdb/errors.py
@@ -1,0 +1,293 @@
+# Copyright 2020 RethinkDB
+#
+# Licensed under the Apache License, Version 2.0 (the 'License');
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an 'AS IS' BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# This file incorporates work covered by the following copyright:
+# Copyright 2010-2016 RethinkDB, all rights reserved.
+
+"""
+This module is the collection of error classes raised by the client.
+"""
+
+__all__ = [
+    "ReqlAuthError",
+    "ReqlCompileError",
+    "ReqlCursorEmpty",
+    "ReqlDriverCompileError",
+    "ReqlDriverError",
+    "ReqlError",
+    "ReqlInternalError",
+    "ReqlNonExistenceError",
+    "ReqlOperationError",
+    "ReqlOpFailedError",
+    "ReqlOpIndeterminateError",
+    "ReqlPermissionError",
+    "ReqlQueryLogicError",
+    "ReqlResourceLimitError",
+    "ReqlRuntimeError",
+    "ReqlServerCompileError",
+    "ReqlTimeoutError",
+    "ReqlUserError",
+]
+
+
+from typing import Dict, List, Optional
+
+
+class QueryPrinter:
+    """
+    Helper class to print Query failures in a formatted was using carets.
+    """
+
+    # TODO: root is RqlQuery - add type when ast is migrated
+    def __init__(self, root, frames: Optional[List[int]] = None) -> None:
+        self.root = root
+        self.frames: List[int] = frames or list()
+
+    @property
+    def query(self) -> str:
+        """
+        Return the composed query.
+        """
+
+        return "".join(self.__compose_term(self.root))
+
+    @property
+    def carets(self) -> str:
+        """
+        Return the carets indicating the location of the failure for the query.
+        """
+
+        return "".join(self.__compose_carets(self.root, self.frames))
+
+    # TODO: term is RqlQuery - add type when ast is migrated
+    def __compose_term(self, term) -> List[str]:
+        """
+        Recursively compose the query term.
+        """
+
+        # TODO: the inner list's elements are terms - add type when ast is migrated
+        args: List[list] = [
+            self.__compose_term(arg)
+            for arg in term._args  # pylint: disable=protected-access)
+        ]
+
+        kwargs: Dict[int, List[str]] = {
+            k: self.__compose_term(v) for k, v in term.optargs.items()
+        }
+
+        return term.compose(args, kwargs)
+
+    # TODO: term is RqlQuery - add type when ast is migrated
+    def __compose_carets(self, term, frames: List[int]) -> List[str]:
+        """
+        Generate the carets for the query term which caused the error.
+        """
+
+        # If the length of the frames is zero, it means that the current frame
+        # is responsible for the error.
+        if len(frames) == 0:
+            return ["^" for _ in self.__compose_term(term)]
+
+        current_frame: int = frames.pop(0)
+
+        args: List[List[str]] = [
+            self.__compose_carets(arg, frames)
+            if current_frame == i
+            else self.__compose_term(arg)
+            for i, arg in enumerate(term._args)  # pylint: disable=protected-access)
+        ]
+
+        kwargs: Dict[int, List[str]] = {}
+        for key, value in term.optargs.items():
+            if current_frame == key:
+                kwargs[key] = self.__compose_carets(value, frames)
+            else:
+                kwargs[key] = self.__compose_term(value)
+
+        return ["^" if i == "^" else " " for i in term.compose(args, kwargs)]
+
+
+class ReqlError(Exception):
+    """
+    Base RethinkDB Query Language Error.
+    """
+
+    # TODO: term is RqlQuery - add type when ast is migrated
+    def __init__(
+        self, message: str, term=None, frames: Optional[List[int]] = None
+    ) -> None:
+        super().__init__(message)
+
+        self.message: str = message
+        self.term = term
+        self.frames: Optional[List[int]] = frames
+        self.__query_printer: Optional[QueryPrinter] = None
+
+        if self.term is not None and self.frames is not None:
+            self.__query_printer = QueryPrinter(self.term, self.frames)
+
+    def __str__(self) -> str:
+        """
+        Return the string representation of the error
+        """
+
+        if self.term is None or self.frames is None:
+            return self.message
+
+        message = self.message.rstrip(".")
+        return f"{message} in:\n{self.__query_printer.query}\n{self.__query_printer.carets}"
+
+    def __repr__(self) -> str:
+        """
+        Return the representation of the error class.
+        """
+
+        return f"<{self.__class__.__name__} instance: {str(self)} >"
+
+
+class ReqlDriverError(ReqlError):
+    """
+    Exception representing the Python client related exceptions.
+    """
+
+
+class ReqlRuntimeError(ReqlError):
+    """
+    Exception representing a runtime issue within the Python client. The runtime error
+    is within the client and not the database.
+    """
+
+
+class ReqlAuthError(ReqlDriverError):
+    """
+    The exception raised when the authentication was unsuccessful to the database
+    server.
+    """
+
+    def __init__(
+        self, message: str, host: Optional[str] = None, port: Optional[int] = None
+    ):
+        if host and port:
+            message = f"Could not connect to {host}:{port}, {message}"
+        elif host and port is None:
+            raise ValueError("If host is set, you must set port as well")
+        elif host is None and port:
+            raise ValueError("If port is set, you must set host as well")
+
+        super().__init__(message)
+
+
+class ReqlOperationError(ReqlRuntimeError):
+    """
+    Exception indicates that the error happened due to availability issues.
+    """
+
+
+class ReqlCompileError(ReqlError):
+    """
+    Exception representing any kind of compilation error. A compilation error
+    can be raised during parsing a Python primitive into a RQL primitive or even
+    when the server cannot parse a RQL primitive, hence it returns an error.
+    """
+
+
+class ReqlDriverCompileError(ReqlCompileError):
+    """
+    Exception indicates that a Python primitive cannot be converted into a
+    RQL primitive.
+    """
+
+
+class ReqlServerCompileError(ReqlCompileError):
+    """
+    Exception indicates that a RQL primitive cannot be parsed by the server, hence
+    it returned an error.
+    """
+
+
+class ReqlCursorEmpty(Exception):
+    """
+    Base exception indicates that the cursor was empty.
+    """
+
+    def __init__(self):
+        self.message = "Cursor is empty."
+        super().__init__(self.message)
+
+
+class ReqlInternalError(ReqlRuntimeError):
+    """
+    Exception indicates that some internal error happened on server side.
+    """
+
+
+class ReqlQueryLogicError(ReqlRuntimeError):
+    """
+    Exception indicates that the query is syntactically correct, but not it has some
+    logical errors.
+    """
+
+
+class ReqlNonExistenceError(ReqlQueryLogicError):
+    """
+    Exception indicates an error related to the absence of an expected value.
+    """
+
+
+class ReqlOpFailedError(ReqlOperationError):
+    """
+    Exception indicates that REQL operation failed.
+    """
+
+
+class ReqlOpIndeterminateError(ReqlOperationError):
+    """
+    Exception indicates that it is unknown whether an operation failed or not.
+    """
+
+
+class ReqlPermissionError(ReqlRuntimeError):
+    """
+    Exception indicates that the connected user has no permission to execute the query.
+    """
+
+
+class ReqlResourceLimitError(ReqlRuntimeError):
+    """
+    Exception indicates that the server exceeded a resource limit (e.g. the array size limit).
+    """
+
+
+class ReqlTimeoutError(ReqlDriverError, TimeoutError):
+    """
+    Exception indicates that the request towards the server is timed out.
+    """
+
+    def __init__(self, host: Optional[str] = None, port: Optional[int] = None):
+        message = "Operation timed out."
+
+        if host and port:
+            message = f"Could not connect to {host}:{port}, {message}"
+        elif host and port is None:
+            raise ValueError("If host is set, you must set port as well")
+        elif host is None and port:
+            raise ValueError("If port is set, you must set host as well")
+
+        super().__init__(message)
+
+
+class ReqlUserError(ReqlRuntimeError):
+    """
+    Exception indicates that en error caused by `r.error` with arguments.
+    """

--- a/rethinkdb/errors.py
+++ b/rethinkdb/errors.py
@@ -142,7 +142,7 @@ class ReqlError(Exception):
         Return the string representation of the error
         """
 
-        if self.term is None or self.frames is None:
+        if self.__query_printer is None:
             return self.message
 
         message = self.message.rstrip(".")

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -2,7 +2,7 @@ from unittest.mock import Mock
 
 import pytest
 
-from rethinkdb.errors import ReqlError, ReqlAuthError, ReqlCursorEmpty, ReqlTimeoutError
+from rethinkdb.errors import ReqlAuthError, ReqlCursorEmpty, ReqlError, ReqlTimeoutError
 
 
 def test_reql_error():
@@ -69,7 +69,7 @@ def test_reql_error_terms_and_frames_are_set():
 
     # TODO: We cannot really test the composed error message until term is not migrated.
     # This is the reason, why we don't use 'reql error in:\ncomposed\n^' as expectation.
-    assert str(exc.value) == 'reql error in:\ncomposed\n '
+    assert str(exc.value) == "reql error in:\ncomposed\n "
     assert repr(exception) == f"<ReqlError instance: {str(exception)} >"
 
 

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -1,0 +1,177 @@
+from unittest.mock import Mock
+
+import pytest
+
+from rethinkdb.errors import ReqlError, ReqlAuthError, ReqlCursorEmpty, ReqlTimeoutError
+
+
+def test_reql_error():
+    """
+    Test raising basic Reql error.
+    """
+
+    expected_message = "reql error"
+    exception = ReqlError(expected_message)
+
+    with pytest.raises(ReqlError) as exc:
+        raise exception
+
+    assert str(exc.value) == expected_message
+    assert repr(exception) == f"<ReqlError instance: {str(exception)} >"
+
+
+def test_reql_error_only_term_is_set():
+    """
+    Test that both term and frames are required to show detailed errors.
+    """
+
+    expected_message = "reql error"
+    exception = ReqlError(expected_message, term=Mock())
+
+    with pytest.raises(ReqlError) as exc:
+        raise exception
+
+    assert str(exc.value) == expected_message
+    assert repr(exception) == f"<ReqlError instance: {str(exception)} >"
+
+
+def test_reql_error_only_frames_are_set():
+    """
+    Test that both term and frames are required to show detailed errors.
+    """
+
+    expected_message = "reql error"
+    exception = ReqlError(expected_message, frames=[1, 2, 3])
+
+    with pytest.raises(ReqlError) as exc:
+        raise exception
+
+    assert str(exc.value) == expected_message
+    assert repr(exception) == f"<ReqlError instance: {str(exception)} >"
+
+
+def test_reql_error_terms_and_frames_are_set():
+    """
+    Test both term and frames are set.
+    """
+
+    inner_term = Mock(_args=[], optargs={})
+    inner_term.compose.return_value = ["^"]
+
+    expected_term = Mock(_name="term", _args=[], optargs={1: inner_term, 2: inner_term})
+    expected_term.compose.return_value = ["composed"]
+
+    expected_message = "reql error"
+    exception = ReqlError(expected_message, term=expected_term, frames=[1, 2])
+
+    with pytest.raises(ReqlError) as exc:
+        raise exception
+
+    # TODO: We cannot really test the composed error message until term is not migrated.
+    # This is the reason, why we don't use 'reql error in:\ncomposed\n^' as expectation.
+    assert str(exc.value) == 'reql error in:\ncomposed\n '
+    assert repr(exception) == f"<ReqlError instance: {str(exception)} >"
+
+
+def test_auth_error():
+    """
+    Test auth error raised as expected without using host or port.
+    """
+
+    expected_message = "auth error"
+
+    with pytest.raises(ReqlAuthError) as exc:
+        raise ReqlAuthError(expected_message)
+
+    assert str(exc.value) == expected_message
+
+
+def test_auth_error_connection_error():
+    """
+    Test auth error shows connection error if host and port are set.
+    """
+
+    host = "localhost"
+    port = 1234
+    message = "auth error"
+
+    with pytest.raises(ReqlAuthError) as exc:
+        raise ReqlAuthError(message, host, port)
+
+    assert str(exc.value) == f"Could not connect to {host}:{port}, {message}"
+
+
+def test_auth_error_only_host():
+    """
+    Test auth error raises error if only host is given.
+    """
+
+    with pytest.raises(ValueError) as exc:
+        raise ReqlAuthError("auth error", host="localhost")
+
+    assert str(exc.value) == "If host is set, you must set port as well"
+
+
+def test_auth_error_only_port():
+    """
+    Test auth error raises error if only port is given.
+    """
+
+    with pytest.raises(ValueError) as exc:
+        raise ReqlAuthError("auth error", port=1234)
+
+    assert str(exc.value) == "If port is set, you must set host as well"
+
+
+def test_cursor_empty():
+    with pytest.raises(ReqlCursorEmpty) as exc:
+        raise ReqlCursorEmpty()
+
+    assert str(exc.value) == "Cursor is empty."
+
+
+def test_timeout_error():
+    """
+    Test timeout error raised as expected without using host or port.
+    """
+
+    with pytest.raises(ReqlTimeoutError) as exc:
+        raise ReqlTimeoutError()
+
+    assert str(exc.value) == "Operation timed out."
+
+
+def test_timeout_error_connection_error():
+    """
+    Test timeout error shows connection error if host and port are set.
+    """
+
+    host = "localhost"
+    port = 1234
+
+    with pytest.raises(ReqlTimeoutError) as exc:
+        raise ReqlTimeoutError(host, port)
+
+    assert str(exc.value) == f"Could not connect to {host}:{port}, Operation timed out."
+
+
+def test_timeout_error_only_host():
+    """
+    Test timeout error raises error if only host is given.
+    """
+
+    with pytest.raises(ValueError) as exc:
+        raise ReqlTimeoutError(host="localhost")
+
+    assert str(exc.value) == "If host is set, you must set port as well"
+
+
+def test_timeout_error_only_port():
+    """
+    Test timeout error raises error if only port is given.
+    """
+
+    with pytest.raises(ValueError) as exc:
+        raise ReqlTimeoutError(port=1234)
+
+    assert str(exc.value) == "If port is set, you must set host as well"


### PR DESCRIPTION
**Description**

This PR ensures that the errors module is moved from the old client.

_Note: The unit tests for `ReqlError` are not 100% correct. See the `TODO` note._

**Code examples**

N/A

**Checklist**

- [x] Unit tests created/updated
- [x] Documentation extended/updated
- [x] I have read and agreed to the [RethinkDB Contributor License Agreement](http://rethinkdb.com/community/cla/)

**References**

N/A
